### PR TITLE
auto prefetch sponsors with automatic pull request

### DIFF
--- a/.github/workflows/prefetch-sponsors.yml
+++ b/.github/workflows/prefetch-sponsors.yml
@@ -1,7 +1,5 @@
 name: prefetch-sponsors
 on:
-  schedule:
-    - cron: '*/15 * * * *'  # Run every 15 minutes
   workflow_dispatch:  # Allow manual triggering
 
 jobs:


### PR DESCRIPTION
- Fix #20 

Here is an example of this feature in action:
- https://github.com/renanfranca/seed4j.github.io/pull/3

How it works:
## The Prevention Mechanism

The key factors that prevent duplicate PRs are:

1. **Fixed branch name**: The workflow always uses the same branch name:
   ```yaml
   branch: prefetch-sponsors/update-sponsor-data
   ```

2. **Built-in logic of `peter-evans/create-pull-request` action**: This action has intelligent behavior:
   - It checks if a branch with the specified name already exists
   - If a branch exists AND there's already an open PR from that branch → it **updates the existing PR** instead of creating a new one
   - If no branch exists → it creates a new branch and PR
   - If branch exists but no open PR → it creates a new PR from the existing branch

3. **Branch cleanup**: The `delete-branch: true` setting ensures that when a PR is merged or closed, the branch gets deleted, allowing for a clean slate on the next run.

## The Flow

1. **First run with changes**: Creates branch `prefetch-sponsors/update-sponsor-data` and opens a PR
2. **Subsequent runs with more changes**: 
   - The action detects the existing branch and open PR
   - **Updates the existing PR** with new commits instead of creating a duplicate
3. **After PR is merged/closed**: Branch is deleted due to `delete-branch: true`
4. **Next run with changes**: Creates a fresh branch and PR